### PR TITLE
Prefer XDG_CURRENT_DESKTOP over DESKTOP_SESSION

### DIFF
--- a/Desktop.py
+++ b/Desktop.py
@@ -25,15 +25,11 @@ def get_desktop_environment():
 
     else:
 
-        desktop_session = os.environ.get('DESKTOP_SESSION')
+        desktop_session = os.environ.get('XDG_CURRENT_DESKTOP')
 
         if desktop_session is None:
 
-            desktop_session = os.environ.get('XDG_CURRENT_DESKTOP')
-
-        elif desktop_session.lower() == 'default':
-
-            desktop_session = os.environ.get('XDG_CURRENT_DESKTOP')
+            desktop_session = os.environ.get('DESKTOP_SESSION')
 
         if desktop_session is not None:
 


### PR DESCRIPTION
`XDG_CURRENT_DESKTOP` is the newer more correct way of detecting the current desktop environment, so it should be preferred over the old `DESKTOP_SESSION` (note session is not the same as desktop environment).

This fixes the desktop detection for the "special" gnome sessions (like gnome-classic and gnome-wayland). It should also work for any users using custom sessions, although I expect that's fairly uncommon.

Hopefully this doesn't break other environments too much...