### PR TITLE
[Fix] city arg sent may not match with the one Yahoo returns

### DIFF
--- a/WeatherDesk.py
+++ b/WeatherDesk.py
@@ -273,7 +273,7 @@ while True:
         weather_json = json.loads(urllib.request.urlopen(weather_json_url).read().decode('utf-8'))
 
         weather = str(weather_json['query']['results']['channel']['item']['condition']['text']).lower()
-
+        city=str(weather_json['query']['results']['channel']['location']['city'])+str(weather_json['query']['results']['channel']['location']['region'])
         print(weather)
         print(city)
 


### PR DESCRIPTION
City argument for Yahoo weather api may not match with the location data it sends back. This may not be a issue when you determine location using IP address , but when user inputs city himself using --city and it doesn't match with Yahoo database, it may be difficult to pinpoint the error.
This commit enables it to print location returned by Yahoo Weather API, instead of city mentioned earlier.