### PR TITLE
Time only flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Either put them in the default `~/.weatherdesk_walls/` directory or specify a di
      "day-" or "night-"
 
      If you use --no-weather, the files have to be named simply after the time of day depending of your time schema.
-     E.g.: "day.{0}", "night.{0}"
+     E.g.: "day.jpg", "night.jpg"
 
 
 ## Supported Platforms

--- a/README.md
+++ b/README.md
@@ -18,37 +18,35 @@ Just download the repository, get some wallpapers (see [the Wallpapers section](
 
     $ python3 WeatherDesk.py --help
     usage: WeatherDesk.py [-h] [-d directory] [-f format] [-w seconds]
-                          [-t [{2,3,4}]] [-n] [-c name [name ...]]
+                          [-t [{2,3,4}]] [-n] [--no-weather] [-c name [name ...]]
+                          [-o]
 
     WeatherDesk - Change the wallpaper based on the weather
-        (Uses the Yahoo! Weather API)
+            (Uses the Yahoo! Weather API)
 
     optional arguments:
       -h, --help            show this help message and exit
-
       -d directory, --dir directory
                             Specify wallpaper directory. Default: ~/.weatherdesk_walls
-
       -f format, --format format
                             Specify image file format. Default: .jpg
-
       -w seconds, --wait seconds
                             Specify time (in seconds) to wait before updating. Default: 600
-
-      -t {2,3,4}, --time {2,3,4}
+      -t [{2,3,4}], --time [{2,3,4}]
                             Use different backgrounds for different times.
 
-                            Variations:
-                              2 = day/night
-                              3 = day/evening/night [Default]
-                              4 = morning/day/evening/night
+                                Variations:
+                                  2 = day/night
+                                  3 = day/evening/night [Default]
+                                  4 = morning/day/evening/night
 
-                            See --naming.
-
+                                See --naming.
       -n, --naming          Show the image file-naming rules and exit.
-
-      -c name, --city name
+      --no-weather          Disable the weather functionality of the script. Wallpapers will only be changed based on the time of day.With this option, no internet connection is required.
+      -c name [name ...], --city name [name ...]
                             Specify city for weather. If not given, taken from ipinfo.io.
+      -o, --one-time-run    Run once, then exit.
+
 
 ## Wallpapers
 
@@ -86,6 +84,9 @@ Either put them in the default `~/.weatherdesk_walls/` directory or specify a di
 
      If using with --time 2, add:
      "day-" or "night-"
+
+     If you use --no-weather, the files have to be named simply after the time of day depending of your time schema.
+     E.g.: "day.{0}", "night.{0}"
 
 
 ## Supported Platforms

--- a/WeatherDesk.py
+++ b/WeatherDesk.py
@@ -58,7 +58,7 @@ _________________________|________________
  "day-" or "night-"
  
  If you use --no-weather, the files have to be named simply after the time of day depending of your time schema.
- E.g.: "day.{0}", "night.{0}"
+ E.g.: "day.jpg", "night.jpg"
 '''
 
 

--- a/WeatherDesk.py
+++ b/WeatherDesk.py
@@ -56,6 +56,9 @@ _________________________|________________
 
  If using with --time 2, add:
  "day-" or "night-"
+ 
+ If you use --no-weather, the files have to be named simply after the time of day depending of your time schema.
+ E.g.: "day.{0}", "night.{0}"
 '''
 
 

--- a/WeatherDesk.py
+++ b/WeatherDesk.py
@@ -103,7 +103,8 @@ def get_args():
 
     arg_parser.add_argument(
         '--no-weather', action='store_true',
-        help='Disable the weather functionality of the script. Wallpapers will only be changed based on the time of day.',
+        help='Disable the weather functionality of the script. Wallpapers will only be changed based on the time of day.'
+             'With this option, no internet connection is required.',
         required=False)
 
     arg_parser.add_argument(


### PR DESCRIPTION
Added an option to disable the weather functionality. With the `--no-weather` flag WeatherDesk will need no internet functionality and will only use the time of the day to change the wallpaper.

Would be cool if someone second could verify, that this works correctly.